### PR TITLE
Bump python versions to current GMSO test coverage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,13 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1 
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8,<=3.11
+    - python >=3.9,<=3.12
     - setuptools
   run:
     - boltons
@@ -25,7 +25,7 @@ requirements:
     - numpy
     - sympy
     - unyt >2.9.5
-    - python >=3.8,<=3.11
+    - python >=3.9,<=3.12
     - pydantic >=2
     - foyer >=0.11.3
     - forcefield-utilities >=0.3.0


### PR DESCRIPTION
GMSO has been testing for python 3.9 - 3.12 for a few months now, but the latest releases didn't adjust the python versions in the recipe file. This changes the python versions from 3.8 - 3.11 to 3.9 - 3.12. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
